### PR TITLE
Ability to disable toggle

### DIFF
--- a/src/nz-toggle.js
+++ b/src/nz-toggle.js
@@ -8,7 +8,8 @@
             scope: {
                 config: '=?',
                 ngModel: '=',
-                onToggle: '&'
+                onToggle: '&',
+                ngDisabled: '=',
             },
             template: [
                 '<div class="nz-toggle-wrap" ng-class="getStyle()" ng-style="wrapStyle">',
@@ -139,6 +140,7 @@
                 }
 
                 function onToggleTouch(e) {
+                    if (vm.ngDisabled) return;
 
                     e = e ? e : window.event;
 
@@ -378,6 +380,8 @@
                 }
 
                 function toggle(state) {
+                    if (vm.ngDisabled) return;
+
                     $timeout(function() {
                         if (!state) {
                             if (vm.state == 'false') {

--- a/src/nz-toggle.styl
+++ b/src/nz-toggle.styl
@@ -19,6 +19,9 @@ vendor-prefixes ?= webkit official
     position: relative
     cursor: pointer
     
+.nz-toggle-wrap[disabled] .nz-toggle
+    cursor: default;
+
 /* Handle */
 .nz-toggle-handle
     border-radius: 20px

--- a/src/nz-toggle.styl
+++ b/src/nz-toggle.styl
@@ -20,7 +20,8 @@ vendor-prefixes ?= webkit official
     cursor: pointer
     
 .nz-toggle-wrap[disabled] .nz-toggle
-    cursor: default;
+    cursor: default
+    opacity: 0.5
 
 /* Handle */
 .nz-toggle-handle


### PR DESCRIPTION
Added attribute `ng-disabled` to `nz-toggle` which provide ability to disable any user interaction with switch. Here is [example](http://codepen.io/anon/pen/BNMVRE).