### PR TITLE
npm cannot handle "main" as an array - must be a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./dist/nz-toggle.js');
+module.exports = 'nzToggle';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nz-toggle",
     "version": "2.2.1",
     "description": "__Double and Triple-State Toggle for AngularJS__",
-    "main": ["dist/nz-toggle.js", "dist/nz-toggle.css"],
+    "main": "dist/nz-toggle.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
     },

--- a/package.json
+++ b/package.json
@@ -2,20 +2,20 @@
     "name": "nz-toggle",
     "version": "2.2.1",
     "description": "__Double and Triple-State Toggle for AngularJS__",
-    "main": "dist/nz-toggle.js",
+    "main": "index.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
     },
     "repository": {
         "type": "git",
-        "url": "git+https://github.com/nozzle/nz-toggle.git"
+        "url": "git+https://github.com/tannerlinsley/nz-toggle.git"
     },
     "author": "Tanner Linsley <tannerlinsley@gmail.com>",
     "license": "ISC",
     "bugs": {
-        "url": "https://github.com/nozzle/nz-toggle/issues"
+        "url": "https://github.com/tannerlinsley/nz-toggle/issues"
     },
-    "homepage": "https://github.com/nozzle/nz-toggle",
+    "homepage": "https://github.com/tannerlinsley/nz-toggle",
     "dependencies": {
         "gulp": "^3.9.0",
         "gulp-ng-annotate": "^1.0.0",


### PR DESCRIPTION
There's currently no way to include CSS in the package.json file, so it will need to be included manually by the developer.

The current package.json does not install with npm install, so this is pretty much the only option. Documentation for npm install could include ways to include the CSS file (I include it with @import in my main.scss file and that works just fine).
