### PR TITLE
Browserify error fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "nz-toggle",
     "version": "2.2.1",
     "description": "__Double and Triple-State Toggle for AngularJS__",
-    "main": ["dist/nz-toggle.js", "dist/nz-toggle.css"],
+    "main": "dist/nz-toggle.js",
     "scripts": {
         "test": "echo \"Error: no test specified\" && exit 1"
     },


### PR DESCRIPTION
The array was giving an error:

```
    throw new TypeError('Path must be a string. Received ' + inspect(path));
    ^

TypeError: Path must be a string. Received [ 'dist/nz-toggle.js', 'dist/nz-toggle.css' ]
```
