### PR TITLE
Dependency to angularjs added

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 
 node_modules/
+nz-toggle.iml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
-
 node_modules/
 nz-toggle.iml

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "nz-toggle",
     "main": ["dist/nz-toggle.js", "dist/nz-toggle.css"],
-    "version": "2.2.3",
+    "version": "2.2.4",
     "homepage": "https://github.com/MetaFactory/nz-toggle",
     "authors": [
         "tannerlinsley"

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "nz-toggle",
     "main": ["dist/nz-toggle.js", "dist/nz-toggle.css"],
-    "version": "2.2.1",
+    "version": "2.2.2",
     "homepage": "https://github.com/nozzle/nz-toggle",
     "authors": [
         "tannerlinsley"
@@ -23,5 +23,8 @@
         "bower_components",
         "test",
         "tests"
-    ]
+    ],
+    "dependencies": {
+        "angular": ">=1.5.8"
+    }
 }

--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
     "name": "nz-toggle",
     "main": ["dist/nz-toggle.js", "dist/nz-toggle.css"],
-    "version": "2.2.2",
-    "homepage": "https://github.com/nozzle/nz-toggle",
+    "version": "2.2.3",
+    "homepage": "https://github.com/MetaFactory/nz-toggle",
     "authors": [
         "tannerlinsley"
     ],

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
-    "name": "nz-toggle",
+    "name": "mf-toggle",
     "main": ["dist/nz-toggle.js", "dist/nz-toggle.css"],
-    "version": "2.2.4",
+    "version": "2.2.5",
     "homepage": "https://github.com/MetaFactory/nz-toggle",
     "authors": [
         "tannerlinsley"


### PR DESCRIPTION
Hi,

We added a dependency to angularjs which solves a runtime problem when we build using the prod profile defined in our gulp file. By adding this dependency gulp (or some of the tools executed by gulp) knows nz-toggle depends on angularjs and gulp knows how to create single js file with all dependencies.